### PR TITLE
Fixed invalid class extends from package

### DIFF
--- a/SMArtInt/Internal/ModelicaUtilityHelper.mo
+++ b/SMArtInt/Internal/ModelicaUtilityHelper.mo
@@ -1,7 +1,6 @@
 within SMArtInt.Internal;
 class ModelicaUtilityHelper
   extends ExternalObject;
-  extends Modelica.Icons.SourcesPackage;
 
   function constructor
     extends Modelica.Icons.Function;
@@ -14,4 +13,21 @@ class ModelicaUtilityHelper
     input ModelicaUtilityHelper modelicaUtiltityHelper;
   external "C" deleteModelicaUtitlityHelper(modelicaUtiltityHelper) annotation (Include="#include \"ModelicaUtilityInterface.cpp\"", IncludeDirectory="modelica://SMArtInt/Resources/Include/");
   end destructor;
+  annotation (Icon(graphics={
+        Rectangle(
+          lineColor={200,200,200},
+          fillColor={248,248,248},
+          fillPattern=FillPattern.HorizontalCylinder,
+          extent={{-100,-100},{100,100}},
+          radius=25.0),
+        Polygon(origin={23.3333,0},
+          fillColor={128,128,128},
+          pattern=LinePattern.None,
+          fillPattern=FillPattern.Solid,
+          points={{-23.333,30.0},{46.667,0.0},{-23.333,-30.0}}),
+        Rectangle(
+          fillColor = {128,128,128},
+          pattern = LinePattern.None,
+          fillPattern = FillPattern.Solid,
+          extent={{-70,-4.5},{0,4.5}})}));
 end ModelicaUtilityHelper;

--- a/SMArtInt/Internal/SMArtIntClass.mo
+++ b/SMArtInt/Internal/SMArtIntClass.mo
@@ -1,7 +1,6 @@
 within SMArtInt.Internal;
 class SMArtIntClass
   extends ExternalObject;
-  extends Modelica.Icons.SourcesPackage;
 
   function constructor
     extends Modelica.Icons.Function;
@@ -30,4 +29,21 @@ class SMArtIntClass
     input SMArtIntClass smartint;
   external "C" NeuralNet_destroyObject(smartint) annotation (Library={"SMArtInt","tensorflowlite_c","onnxruntime_c"}, LibraryDirectory="modelica://SMArtInt/Resources/Library");
   end destructor;
+  annotation (Icon(graphics={
+        Rectangle(
+          lineColor={200,200,200},
+          fillColor={248,248,248},
+          fillPattern=FillPattern.HorizontalCylinder,
+          extent={{-100,-100},{100,100}},
+          radius=25.0),
+        Rectangle(
+          fillColor = {128,128,128},
+          pattern = LinePattern.None,
+          fillPattern = FillPattern.Solid,
+          extent={{-70,-4.5},{0,4.5}}),
+        Polygon(origin={23.3333,0},
+          fillColor={128,128,128},
+          pattern=LinePattern.None,
+          fillPattern=FillPattern.Solid,
+          points={{-23.333,30.0},{46.667,0.0},{-23.333,-30.0}})}));
 end SMArtIntClass;


### PR DESCRIPTION
### Refactor classes: remove illegal package extends and add Icons directly

Previously, several classes used 'extends package', which is not allowed.
Icons are now defined directly in the respective classes.

Closes: #8 