### PR TITLE
Fixed problematic Include usage in SMArtInt.Internal.ModelicaUtilityHelper

### DIFF
--- a/SMArtInt/Resources/Include/ModelicaUtilityInterface.cpp
+++ b/SMArtInt/Resources/Include/ModelicaUtilityInterface.cpp
@@ -6,14 +6,14 @@
 
 static ModelicaUtilityHelper s_ModelicaUtilityHelper;
 
-void* createModelicaUtitlityHelper()
+static void* createModelicaUtitlityHelper()
 {
 	s_ModelicaUtilityHelper.ModelicaError = ModelicaError;
 	s_ModelicaUtilityHelper.ModelicaMessage = ModelicaMessage;
 	return &s_ModelicaUtilityHelper;
 }
 
-void deleteModelicaUtitlityHelper(void* externalObject)
+static void deleteModelicaUtitlityHelper(void* externalObject)
 {
 
 }


### PR DESCRIPTION
Make functions createModelicaUtilityHelper & deleteModelicaUtilityHelper static

This avoids linker errors when ModelicaUtilityInterface.cpp is directly included in Modelica.

Closes: #12 